### PR TITLE
Add doc on how to extend encore

### DIFF
--- a/Resources/docs/README.md
+++ b/Resources/docs/README.md
@@ -8,7 +8,6 @@ If you cannot find the needed information in this list of topics, please create 
 * [Breadcrumb Menu](breadcrumbs.md)
 * [Form theme](form_theme.md)
 * [Twig extensions](twig_widgets.md)
-* [Building frontend assets](frontend_assets.md)
 * [FOSUserBundle integration](fos_userbundle.md)
 
 Customizing the left menu-sidebar:
@@ -30,6 +29,7 @@ Customizing the right control sidebar:
 
 Extending webpack-encore:
 
+* [Building frontend assets](frontend_assets.md)
 * [Extend Webpack Encore](extend_webpack_encore.md)
 
 For the users how come from the original AdminThemeBundle:

--- a/Resources/docs/README.md
+++ b/Resources/docs/README.md
@@ -28,6 +28,10 @@ Customizing the right control sidebar:
 
 * [Control Sidebar](control_sidebar.md)
 
+Extending webpack-encore:
+
+* [Extend Webpack Encore](extend_webpack_encore.md)
+
 For the users how come from the original AdminThemeBundle:
 
 * [Migrating from AdminThemeBundle](migration_guide.md)

--- a/Resources/docs/extend_webpack_encore.md
+++ b/Resources/docs/extend_webpack_encore.md
@@ -39,7 +39,7 @@ require('../../vendor/kevinpapst/adminlte-bundle/Resources/assets/admin-lte');
 
 ```
 
-Then, if you didn't alread did, install all packages and build your assets:
+Then, if you didn't already did it, install all packages and build your assets:
 
 ```bash
 user@devpc:/var/www/symfony-project$ yarn install

--- a/Resources/docs/extend_webpack_encore.md
+++ b/Resources/docs/extend_webpack_encore.md
@@ -1,0 +1,81 @@
+## Extend Webpack Encore
+
+If you are going to use your customized webpack-encore configuration and
+want to take advantage of all the libraries imported from AdminLTEBundle, 
+you can easily extend its configuration.
+
+### Create your webpack.config.js
+
+First of all, create your own webpack.config.js, as in [Symfony documentation](http://symfony.com/doc/current/frontend/encore/simple-example.html):
+
+```js
+var Encore = require('@symfony/webpack-encore');
+
+Encore
+    .setOutputPath('public/builds/')
+    .setPublicPath('/builds')
+
+    // this will be your app!
+    .addEntry('app', './assets/js/app.js')
+    .autoProvidejQuery()
+    .enableSourceMaps(!Encore.isProduction())
+    .cleanupOutputBeforeBuild()
+    .enableBuildNotifications()
+    // You need sass loader!
+    .enableSassLoader()
+;
+
+module.exports = Encore.getWebpackConfig();
+```
+
+Now you need to create (or update) your `package.json`. If you don't have one, copy
+[package.json](../../package.json) from AdminLTEBundle. If you already have one, then
+integrate it with the packages listed in `vendor/kevinpapst/adminlte-bundle/package.json`.  
+
+Then create your main app and require adminlte:
+```js
+// assets/js/app.js
+require('../../vendor/kevinpapst/adminlte-bundle/Resources/assets/admin-lte');
+
+```
+
+Then, if you didn't alread did, install all packages and build your assets:
+
+```bash
+user@devpc:/var/www/symfony-project$ yarn install
+[...]
+user@devpc:/var/www/symfony-project$ ./node_modules/.bin/encore production
+
+```
+### Correct the assets path
+
+Now you have to update your assets path. To do this, create a new template
+that is going to extend AdminLTEBundle main template:
+
+```yaml
+{# templates/base.html.twig #}
+
+{% extends '@AdminLTE/layout/default-layout.html.twig' %}
+
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('builds/app.css') }}">
+{% endblock %}
+
+{% block javascripts %}
+    <script src="{{ asset('builds/app.js') }}"></script>
+{% endblock %}
+
+```
+
+And finally, in your project, extend your `templates/base.html.twig` when rendering 
+your pages:
+
+```twig
+{% extends 'base.html.twig' %}
+```
+
+Now, you can edit your `webpack.config.js` as you need. 
+
+## Next steps
+
+Please go back to the [AdminLTE bundle documentation](README.md) to find out more about using the theme.

--- a/Resources/docs/extend_webpack_encore.md
+++ b/Resources/docs/extend_webpack_encore.md
@@ -36,23 +36,22 @@ Then create your main app and require adminlte:
 ```js
 // assets/js/app.js
 require('../../vendor/kevinpapst/adminlte-bundle/Resources/assets/admin-lte');
-
 ```
 
-Then, if you didn't already did it, install all packages and build your assets:
+Then, if you haven't done it already, install all packages and build your assets:
 
 ```bash
-user@devpc:/var/www/symfony-project$ yarn install
+yarn install
 [...]
-user@devpc:/var/www/symfony-project$ ./node_modules/.bin/encore production
-
+./node_modules/.bin/encore production
 ```
+
 ### Correct the assets path
 
 Now you have to update your assets path. To do this, create a new template
 that is going to extend AdminLTEBundle main template:
 
-```yaml
+```twig
 {# templates/base.html.twig #}
 
 {% extends '@AdminLTE/layout/default-layout.html.twig' %}
@@ -64,7 +63,6 @@ that is going to extend AdminLTEBundle main template:
 {% block javascripts %}
     <script src="{{ asset('builds/app.js') }}"></script>
 {% endblock %}
-
 ```
 
 And finally, in your project, extend your `templates/base.html.twig` when rendering 


### PR DESCRIPTION
<!-- All my contributions adhere implicitly to the MIT license -->
As discussed on #5, this PR adds a new documentation page on how to extends AdminLTEBundle webpack.config.js

It is based on the [AdminLTEBundle-Demo](https://github.com/kevinpapst/AdminLTEBundle-Demo) app.
