### PR TITLE
Fix rest of Symfony 4.2 deprecations

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,10 +48,15 @@ class Configuration implements ConfigurationInterface
 
     private function getRouteAliasesConfig()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('routes');
+        $treeBuilder = new TreeBuilder('routes');
 
-        $node
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('routes');
+        }
+
+        $rootNode
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('adminlte_welcome')
@@ -105,15 +110,20 @@ class Configuration implements ConfigurationInterface
             ->end()
         ->end();
 
-        return $node;
+        return $rootNode;
     }
 
     private function getKnpMenuConfig()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('knp_menu');
+        $treeBuilder = new TreeBuilder('knp_menu');
 
-        $node
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('knp_menu');
+        }
+
+        $rootNode
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('enable')
@@ -131,15 +141,20 @@ class Configuration implements ConfigurationInterface
             ->end()
         ->end();
 
-        return $node;
+        return $rootNode;
     }
 
     private function getWidgetConfig()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('widget');
+        $treeBuilder = new TreeBuilder('widget');
 
-        $node
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('widget');
+        }
+
+        $rootNode
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('collapsible_title')
@@ -177,15 +192,20 @@ class Configuration implements ConfigurationInterface
             ->end()
         ->end();
 
-        return $node;
+        return $rootNode;
     }
 
     private function getButtonConfig()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('button');
+        $treeBuilder = new TreeBuilder('button');
 
-        $node
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('button');
+        }
+
+        $rootNode
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('type')
@@ -199,15 +219,20 @@ class Configuration implements ConfigurationInterface
             ->end()
         ->end();
 
-        return $node;
+        return $rootNode;
     }
 
     private function getThemeConfig()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('theme');
+        $treeBuilder = new TreeBuilder('theme');
 
-        $node
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('theme');
+        }
+
+        $rootNode
             ->addDefaultsIfNotSet()
             ->children()
                 ->append($this->getWidgetConfig())
@@ -215,15 +240,20 @@ class Configuration implements ConfigurationInterface
             ->end()
         ->end();
 
-        return $node;
+        return $rootNode;
     }
 
     private function getOptionsConfig()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('options');
+        $treeBuilder = new TreeBuilder('options');
 
-        $node
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('options');
+        }
+
+        $rootNode
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('default_avatar')
@@ -253,15 +283,20 @@ class Configuration implements ConfigurationInterface
             ->end()
         ->end();
 
-        return $node;
+        return $rootNode;
     }
 
     private function getControlSidebarConfig()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('control_sidebar');
+        $treeBuilder = new TreeBuilder('control_sidebar');
 
-        $node
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('control_sidebar');
+        }
+
+        $rootNode
             ->arrayPrototype()
                 ->children()
                     ->scalarNode('icon')->end()
@@ -272,6 +307,6 @@ class Configuration implements ConfigurationInterface
             ->info('controls all panels in the right control_sidebar')
         ->end();
 
-        return $node;
+        return $rootNode;
     }
 }

--- a/Resources/translations/AdminLTEBundle.ar.xliff
+++ b/Resources/translations/AdminLTEBundle.ar.xliff
@@ -62,17 +62,17 @@
                 <source>View all</source>
                 <target>عرض الكل</target>
             </trans-unit>
-            <trans-unit id="You have %total% notifications">
-                <source>You have %total% notifications</source>
-                <target>{count, plural, one {You have # notification} other {You have # notifications}}</target>
+            <trans-unit id="You have %count% notifications">
+                <source>You have %count% notifications</source>
+                <target>لديك %count% إشعارات</target>
             </trans-unit>
-            <trans-unit id="You have %total% messages">
-                <source>You have %total% messages</source>
-                <target>{count, plural, one {You have # message} other {You have # messages}}</target>
+            <trans-unit id="You have %count% messages">
+                <source>You have %count% messages</source>
+                <target>لديك %count% رسائل</target>
             </trans-unit>
-            <trans-unit id="You have %total% tasks">
-                <source>You have %total% tasks</source>
-                <target>{count, plural, one {You have # task} other {You have # tasks}}</target>
+            <trans-unit id="You have %count% tasks">
+                <source>You have %count% tasks</source>
+                <target>لديك %count% مهام</target>
             </trans-unit>
             <trans-unit id="%progress%% Complete">
                 <source>%progress%% Complete</source>

--- a/Resources/translations/AdminLTEBundle.cs.xliff
+++ b/Resources/translations/AdminLTEBundle.cs.xliff
@@ -62,21 +62,25 @@
                 <source>View all</source>
                 <target>Zobrazit vše</target>
             </trans-unit>
-            <trans-unit id="You have %total% notifications">
-                <source>You have %total% notifications</source>
-                <target>{count, plural, one {Máte # notifikaci} few {Máte # notifikace} other {Máte # notifikací}}</target>
+            <trans-unit id="You have %count% notifications">
+                <source>You have %count% notifications</source>
+                <target>{1} Máte 1 notifikaci|[2,4] Máte %count% notifikace|[5,Inf[ Máte %count% notifikací</target>
             </trans-unit>
-            <trans-unit id="You have %total% messages">
-                <source>You have %total% messages</source>
-                <target>{count, plural, one {Máte # zprávu} few {Máte # zprávy} other {Máte # zpráv}}</target>
+            <trans-unit id="You have %count% messages">
+                <source>You have %count% messages</source>
+                <target>{1} Máte 1 zprávu|[2,4] Máte %count% zprávy|[5,Inf[ Máte %count% zpráv</target>
             </trans-unit>
-            <trans-unit id="You have %total% tasks">
-                <source>You have %total% tasks</source>
-                <target>{count, plural, one {Máte # úkol} few {Máte # úkoly} other {Máte # úkolů}}</target>
+            <trans-unit id="You have %count% tasks">
+                <source>You have %count% tasks</source>
+                <target>{1} Máte 1 úkol|[2,4] Máte %count% úkoly|[5,Inf[ Máte %count% úkolů</target>
             </trans-unit>
             <trans-unit id="%progress%% Complete">
                 <source>%progress%% Complete</source>
                 <target>%progress%% hotovo</target>
+            </trans-unit>
+            <trans-unit id="This is a mandatory field">
+                <source>This is a mandatory field</source>
+                <target>Toto je povinné pole</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.de.xliff
+++ b/Resources/translations/AdminLTEBundle.de.xliff
@@ -62,21 +62,25 @@
                 <source>View all</source>
                 <target>Alle anzeigen</target>
             </trans-unit>
-            <trans-unit id="You have %total% notifications">
-                <source>You have %total% notifications</source>
-                <target>{count, plural, one {Du hast # Benachrichtigung} other {Du hast # Benachrichtigungen}}</target>
+            <trans-unit id="You have %count% notifications">
+                <source>You have %count% notifications</source>
+                <target>Du hast 1 Benachrichtigung|Du hast %count% Benachrichtigungen</target>
             </trans-unit>
-            <trans-unit id="You have %total% messages">
-                <source>You have %total% messages</source>
-                <target>{count, plural, one {Du hast # Nachricht} other {Du hast # Nachrichten}}</target>
+            <trans-unit id="You have %count% messages">
+                <source>You have %count% messages</source>
+                <target>Du hast 1 Nachricht|Due hast %count% Nachrichten</target>
             </trans-unit>
-            <trans-unit id="You have %total% tasks">
-                <source>You have %total% tasks</source>
-                <target>{count, plural, one {Du hast # Aufgabe} other {Du hast # Aufgaben}}</target>
+            <trans-unit id="You have %count% tasks">
+                <source>You have %count% tasks</source>
+                <target>Du hast 1 Aufgabe|Du hast %count% Aufgaben</target>
             </trans-unit>
             <trans-unit id="%progress%% Complete">
                 <source>%progress%% Complete</source>
                 <target>%progress%% erledigt</target>
+            </trans-unit>
+            <trans-unit id="This is a mandatory field">
+                <source>This is a mandatory field</source>
+                <target>Dies ist ein Pflichtfeld</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.en.xliff
+++ b/Resources/translations/AdminLTEBundle.en.xliff
@@ -62,21 +62,25 @@
                 <source>View all</source>
                 <target>View all</target>
             </trans-unit>
-            <trans-unit id="You have %total% notifications">
-                <source>You have %total% notifications</source>
-                <target>{count, plural, one {You have # notification} other {You have # notifications}}</target>
+            <trans-unit id="You have %count% notifications">
+                <source>You have %count% notifications</source>
+                <target>You have 1 notification|You have %count% notifications</target>
             </trans-unit>
-            <trans-unit id="You have %total% messages">
-                <source>You have %total% messages</source>
-                <target>{count, plural, one {You have # message} other {You have # messages}}</target>
+            <trans-unit id="You have %count% messages">
+                <source>You have %count% messages</source>
+                <target>You have 1 message|You have %count% messages</target>
             </trans-unit>
-            <trans-unit id="You have %total% tasks">
-                <source>You have %total% tasks</source>
-                <target>{count, plural, one {You have # task} other {You have # tasks}}</target>
+            <trans-unit id="You have %count% tasks">
+                <source>You have %count% tasks</source>
+                <target>You have 1 task|You have %count% tasks</target>
             </trans-unit>
             <trans-unit id="%progress%% Complete">
                 <source>%progress%% Complete</source>
                 <target>%progress%% completed</target>
+            </trans-unit>
+            <trans-unit id="This is a mandatory field">
+                <source>This is a mandatory field</source>
+                <target>This is a mandatory field</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.it.xliff
+++ b/Resources/translations/AdminLTEBundle.it.xliff
@@ -62,17 +62,17 @@
                 <source>View all</source>
                 <target>View all</target>
             </trans-unit>
-            <trans-unit id="You have %total% notifications">
-                <source>You have %total% notifications</source>
-                <target>{count, plural, one {You have # notification} other {You have # notifications}}</target>
+            <trans-unit id="You have %count% notifications">
+                <source>You have %count% notifications</source>
+                <target>You have 1 notification|You have %count% notifications</target>
             </trans-unit>
-            <trans-unit id="You have %total% messages">
-                <source>You have %total% messages</source>
-                <target>{count, plural, one {You have # message} other {You have # messages}}</target>
+            <trans-unit id="You have %count% messages">
+                <source>You have %count% messages</source>
+                <target>You have 1 message|You have %count% messages</target>
             </trans-unit>
-            <trans-unit id="You have %total% tasks">
-                <source>You have %total% tasks</source>
-                <target>{count, plural, one {You have # task} other {You have # tasks}}</target>
+            <trans-unit id="You have %count% tasks">
+                <source>You have %count% tasks</source>
+                <target>You have 1 task|You have %count% tasks</target>
             </trans-unit>
             <trans-unit id="%progress%% Complete">
                 <source>%progress%% Complete</source>

--- a/Resources/translations/AdminLTEBundle.ru.xliff
+++ b/Resources/translations/AdminLTEBundle.ru.xliff
@@ -62,17 +62,17 @@
                 <source>View all</source>
                 <target>View all</target>
             </trans-unit>
-            <trans-unit id="You have %total% notifications">
-                <source>You have %total% notifications</source>
-                <target>{count, plural, one {You have # notification} other {You have # notifications}}</target>
+            <trans-unit id="You have %count% notifications">
+                <source>You have %count% notifications</source>
+                <target>You have 1 notification|You have %count% notifications</target>
             </trans-unit>
-            <trans-unit id="You have %total% messages">
-                <source>You have %total% messages</source>
-                <target>{count, plural, one {You have # message} other {You have # messages}}</target>
+            <trans-unit id="You have %count% messages">
+                <source>You have %count% messages</source>
+                <target>You have 1 message|You have %count% messages</target>
             </trans-unit>
-            <trans-unit id="You have %total% tasks">
-                <source>You have %total% tasks</source>
-                <target>{count, plural, one {You have # task} other {You have # tasks}}</target>
+            <trans-unit id="You have %count% tasks">
+                <source>You have %count% tasks</source>
+                <target>You have 1 task|You have %count% tasks</target>
             </trans-unit>
             <trans-unit id="%progress%% Complete">
                 <source>%progress%% Complete</source>

--- a/Resources/views/Navbar/messages.html.twig
+++ b/Resources/views/Navbar/messages.html.twig
@@ -5,7 +5,7 @@
         <span class="label label-success">{{ total }}</span>
     </a>
     <ul class="dropdown-menu">
-        <li class="header">{{ 'You have %total% messages'|trans({'count':total}, 'AdminLTEBundle') }}</li>
+        <li class="header">{{ 'You have %count% messages'|trans({'%count%':total}, 'AdminLTEBundle') }}</li>
         <li>
             <ul class="menu">
                 {% for msg in messages %}

--- a/Resources/views/Navbar/notifications.html.twig
+++ b/Resources/views/Navbar/notifications.html.twig
@@ -4,7 +4,7 @@
         <span class="label label-warning">{{ total }}</span>
     </a>
     <ul class="dropdown-menu">
-        <li class="header">{{ 'You have %total% notifications'|trans({'count': total}, 'AdminLTEBundle') }}</li>
+        <li class="header">{{ 'You have %count% notifications'|trans({'%count%':total}, 'AdminLTEBundle') }}</li>
         <li>
             <ul class="menu">
                 {% for notice in notifications %}

--- a/Resources/views/Navbar/tasks.html.twig
+++ b/Resources/views/Navbar/tasks.html.twig
@@ -4,7 +4,7 @@
         <span class="label label-danger">{{ total }}</span>
     </a>
     <ul class="dropdown-menu">
-        <li class="header">{{ 'You have %total% tasks' |trans({'count':total}, 'AdminLTEBundle') }}</li>
+        <li class="header">{{ 'You have %count% tasks' |trans({'%count%':total}, 'AdminLTEBundle') }}</li>
         <li>
             <ul class="menu">
                 {% for task in tasks %}


### PR DESCRIPTION
I could not update your original PR, so here it comes as a new one.

First: you wanted to use IntlMessageFormatter for the transchoice translations and that would cause BC with originally supported locales. I decide to go other way using %count% parameter which is working with trans() filter and I believe it does not introduce BC.

Second: I did not find anymore warnings to fix, so the greatest part was done by you already.