### PR TITLE
fix spaceless tag deprecation

### DIFF
--- a/Resources/views/Breadcrumb/knp-breadcrumb.html.twig
+++ b/Resources/views/Breadcrumb/knp-breadcrumb.html.twig
@@ -1,12 +1,12 @@
 {% if admin_lte_context.knp_menu.breadcrumb_menu is not same as(false) %}
     <ol class="breadcrumb">
-        {% spaceless %}
+        {% filter spaceless %}
             {% set breadcrumbMenu = admin_lte_context.knp_menu.breadcrumb_menu %}
             {% if admin_lte_context.knp_menu.breadcrumb_menu is same as(true) %}
                 {% set breadcrumbMenu = admin_lte_context.knp_menu.main_menu %}
             {% endif %}
             {% set items = knp_menu_get_breadcrumbs_array(knp_menu_get_current_item(breadcrumbMenu)) %}
-        {% endspaceless %}
+        {% endfilter %}
         {% for item in items %}
             {% if not loop.first %}
             <li class="{{ loop.last ? 'active' : '' }}">

--- a/Resources/views/layout/form-theme-horizontal.html.twig
+++ b/Resources/views/layout/form-theme-horizontal.html.twig
@@ -6,7 +6,7 @@
 #}
 
 {% block form_errors %}
-    {% spaceless %}
+    {% filter spaceless %}
         {% if errors|length > 0 %}
             <ul class="list-unstyled">
                 {% for error in errors %}
@@ -14,7 +14,7 @@
                 {% endfor %}
             </ul>
         {% endif %}
-    {% endspaceless %}
+    {% endfilter %}
 {% endblock form_errors %}
 
 {% block widget_attributes %}
@@ -42,13 +42,13 @@
 {% endblock widget_attributes %}
 
 {% block choice_widget_expanded %}
-    {% spaceless %}
+    {% filter spaceless %}
         <div {{ block('widget_container_attributes') }}>
             {% for child in form %}
                 {{ form_widget(child) }}
             {% endfor %}
         </div>
-    {% endspaceless %}
+    {% endfilter %}
 {% endblock choice_widget_expanded %}
 
 {% block choice_widget_collapsed %}
@@ -64,7 +64,7 @@
 
 {% block checkbox_widget %}
     <div class="checkbox">
-        {% spaceless %}
+        {% filter spaceless %}
             {% if not compound %}
                 {% set label_attr = label_attr|merge({'for': id}) %}
             {% endif %}
@@ -81,13 +81,13 @@
                 {{ label|trans({}, translation_domain) }}
             {% endif %}
             </label>
-        {% endspaceless %}
+        {% endfilter %}
     </div>
 {% endblock checkbox_widget %}
 
 {% block radio_widget %}
     <div class="radio">
-        {% spaceless %}
+        {% filter spaceless %}
             {% if not compound %}
                 {% set label_attr = label_attr|merge({'for': id}) %}
             {% endif %}
@@ -103,7 +103,7 @@
                 {{ label|trans({}, translation_domain) }}
             {% endif %}
             </label>
-        {% endspaceless %}
+        {% endfilter %}
     </div>
 {% endblock radio_widget %}
 

--- a/Resources/views/layout/form-theme.html.twig
+++ b/Resources/views/layout/form-theme.html.twig
@@ -6,7 +6,7 @@
 #}
 
 {% block form_errors %}
-    {% spaceless %}
+    {% filter spaceless %}
         {% if errors|length > 0 %}
             <ul class="list-unstyled">
                 {% for error in errors %}
@@ -14,7 +14,7 @@
                 {% endfor %}
             </ul>
         {% endif %}
-    {% endspaceless %}
+    {% endfilter %}
 {% endblock form_errors %}
 
 {% block widget_attributes %}
@@ -42,13 +42,13 @@
 {% endblock widget_attributes %}
 
 {% block choice_widget_expanded %}
-    {% spaceless %}
+    {% filter spaceless %}
         <div {{ block('widget_container_attributes') }}>
             {% for child in form %}
                 {{ form_widget(child) }}
             {% endfor %}
         </div>
-    {% endspaceless %}
+    {% endfilter %}
 {% endblock choice_widget_expanded %}
 
 {% block choice_widget_collapsed %}
@@ -64,7 +64,7 @@
 
 {% block checkbox_widget %}
     <div class="checkbox">
-        {% spaceless %}
+        {% filter spaceless %}
             {% if not compound %}
                 {% set label_attr = label_attr|merge({'for': id}) %}
             {% endif %}
@@ -81,13 +81,13 @@
                 {{ label|trans({}, translation_domain) }}
             {% endif %}
             </label>
-        {% endspaceless %}
+        {% endfilter %}
     </div>
 {% endblock checkbox_widget %}
 
 {% block radio_widget %}
     <div class="radio">
-        {% spaceless %}
+        {% filter spaceless %}
             {% if not compound %}
                 {% set label_attr = label_attr|merge({'for': id}) %}
             {% endif %}
@@ -103,7 +103,7 @@
                 {{ label|trans({}, translation_domain) }}
             {% endif %}
             </label>
-        {% endspaceless %}
+        {% endfilter %}
     </div>
 {% endblock radio_widget %}
 


### PR DESCRIPTION
<!-- All my contributions adhere implicitly to the MIT license -->

Fixes the deprecation that was introduced with Twig 2.7, see https://twig.symfony.com/doc/2.x/deprecated.html

Replacing the `{% spaceless %}` tag with `{% filter spaceless %}`