### PR TITLE
Deprecation fixes

### DIFF
--- a/Controller/BreadcrumbController.php
+++ b/Controller/BreadcrumbController.php
@@ -38,7 +38,7 @@ class BreadcrumbController extends EmitterController
         }
 
         /** @var SidebarMenuEvent $event */
-        $event = $this->getDispatcher()->dispatch(ThemeEvents::THEME_BREADCRUMB, new SidebarMenuEvent($request));
+        $event = $this->getDispatcher()->dispatch(new SidebarMenuEvent($request), ThemeEvents::THEME_BREADCRUMB);
         /** @var MenuItemInterface $active */
         $active = $event->getActive();
         $list = [];

--- a/Controller/EmitterController.php
+++ b/Controller/EmitterController.php
@@ -11,8 +11,8 @@ namespace KevinPapst\AdminLTEBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class EmitterController extends AbstractController
 {
@@ -53,12 +53,12 @@ class EmitterController extends AbstractController
      *
      * Then it will dispatch the event as normal via the event dispatcher.
      *
-     * @param string $eventName
      * @param Event $event
+     * @param string $eventName
      *
      * @return Event
      */
-    protected function triggerMethod($eventName, Event $event)
+    protected function triggerMethod(Event $event, $eventName)
     {
         $method = sprintf('on%s', Container::camelize(str_replace('.', '_', $eventName)));
 
@@ -70,7 +70,7 @@ class EmitterController extends AbstractController
             return $event;
         }
 
-        $this->getDispatcher()->dispatch($eventName, $event);
+        $this->getDispatcher()->dispatch($event, $eventName);
 
         return $event;
     }

--- a/Controller/NavbarController.php
+++ b/Controller/NavbarController.php
@@ -15,7 +15,7 @@ use KevinPapst\AdminLTEBundle\Event\ShowUserEvent;
 use KevinPapst\AdminLTEBundle\Event\TaskListEvent;
 use KevinPapst\AdminLTEBundle\Event\ThemeEvents;
 use KevinPapst\AdminLTEBundle\Helper\ContextHelper;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 class NavbarController extends EmitterController
@@ -47,7 +47,7 @@ class NavbarController extends EmitterController
         }
 
         /** @var NotificationListEvent $listEvent */
-        $listEvent = $this->getDispatcher()->dispatch(ThemeEvents::THEME_NOTIFICATIONS, new NotificationListEvent($max));
+        $listEvent = $this->getDispatcher()->dispatch(new NotificationListEvent($max), ThemeEvents::THEME_NOTIFICATIONS);
 
         return $this->render(
             '@AdminLTE/Navbar/notifications.html.twig',
@@ -74,7 +74,7 @@ class NavbarController extends EmitterController
         }
 
         /** @var MessageListEvent $listEvent */
-        $listEvent = $this->getDispatcher()->dispatch(ThemeEvents::THEME_MESSAGES, new MessageListEvent($max));
+        $listEvent = $this->getDispatcher()->dispatch(new MessageListEvent($max), ThemeEvents::THEME_MESSAGES);
 
         return $this->render(
             '@AdminLTE/Navbar/messages.html.twig',
@@ -101,7 +101,7 @@ class NavbarController extends EmitterController
         }
 
         /** @var TaskListEvent $listEvent */
-        $listEvent = $this->triggerMethod(ThemeEvents::THEME_TASKS, new TaskListEvent($max));
+        $listEvent = $this->triggerMethod(new TaskListEvent($max), ThemeEvents::THEME_TASKS);
 
         return $this->render(
             '@AdminLTE/Navbar/tasks.html.twig',
@@ -122,7 +122,7 @@ class NavbarController extends EmitterController
         }
 
         /** @var ShowUserEvent $userEvent */
-        $userEvent = $this->triggerMethod(ThemeEvents::THEME_NAVBAR_USER, new ShowUserEvent());
+        $userEvent = $this->triggerMethod(new ShowUserEvent(), ThemeEvents::THEME_NAVBAR_USER);
 
         if ($userEvent instanceof ShowUserEvent && null !== $userEvent->getUser()) {
             return $this->render(

--- a/Controller/SidebarController.php
+++ b/Controller/SidebarController.php
@@ -27,7 +27,7 @@ class SidebarController extends EmitterController
         }
 
         /** @var ShowUserEvent $userEvent */
-        $userEvent = $this->getDispatcher()->dispatch(ThemeEvents::THEME_SIDEBAR_USER, new ShowUserEvent());
+        $userEvent = $this->getDispatcher()->dispatch(new ShowUserEvent(), ThemeEvents::THEME_SIDEBAR_USER);
 
         return $this->render(
             '@AdminLTE/Sidebar/user-panel.html.twig',
@@ -56,7 +56,7 @@ class SidebarController extends EmitterController
         }
 
         /** @var SidebarMenuEvent $event */
-        $event = $this->getDispatcher()->dispatch(ThemeEvents::THEME_SIDEBAR_SETUP_MENU, new SidebarMenuEvent($request));
+        $event = $this->getDispatcher()->dispatch(new SidebarMenuEvent($request), ThemeEvents::THEME_SIDEBAR_SETUP_MENU);
 
         return $this->render(
             '@AdminLTE/Sidebar/menu.html.twig',

--- a/Event/ThemeEvent.php
+++ b/Event/ThemeEvent.php
@@ -9,7 +9,7 @@
 
 namespace KevinPapst\AdminLTEBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Base event class to make theme related events easier to detect

--- a/Resources/views/Breadcrumb/knp-breadcrumb.html.twig
+++ b/Resources/views/Breadcrumb/knp-breadcrumb.html.twig
@@ -1,6 +1,6 @@
 {% if admin_lte_context.knp_menu.breadcrumb_menu is not same as(false) %}
     <ol class="breadcrumb">
-        {% filter spaceless %}
+        {% apply spaceless %}
             {% set breadcrumbMenu = admin_lte_context.knp_menu.breadcrumb_menu %}
             {% if admin_lte_context.knp_menu.breadcrumb_menu is same as(true) %}
                 {% set breadcrumbMenu = admin_lte_context.knp_menu.main_menu %}
@@ -13,6 +13,6 @@
                 </li>
                 {% endif %}
             {% endfor %}
-        {% endfilter %}
+        {% endapply %}
     </ol>
 {% endif %}

--- a/Resources/views/layout/default-layout.html.twig
+++ b/Resources/views/layout/default-layout.html.twig
@@ -50,16 +50,16 @@ fixed, layout-boxed, layout-top-nav, sidebar-collapse, sidebar-mini
                 <ul class="nav navbar-nav">
                     {% block navbar_start %}{% endblock %}
                     {% block navbar_messages %}
-                        {{ render(controller('AdminLTEBundle:Navbar:messages')) }}
+                        {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\NavbarController::messagesAction')) }}
                     {% endblock %}
                     {% block navbar_notifications %}
-                        {{ render(controller('AdminLTEBundle:Navbar:notifications')) }}
+                        {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\NavbarController::notificationsAction')) }}
                     {% endblock %}
                     {% block navbar_tasks %}
-                        {{ render(controller('AdminLTEBundle:Navbar:tasks')) }}
+                        {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\NavbarController::tasksAction')) }}
                     {% endblock %}
                     {% block navbar_user %}
-                        {{ render(controller('AdminLTEBundle:Navbar:user')) }}
+                        {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\NavbarController::userAction')) }}
                     {% endblock %}
                     {% block navbar_end %}{% endblock %}
                     {% block navbar_control_sidebar_toggle %}
@@ -78,19 +78,19 @@ fixed, layout-boxed, layout-top-nav, sidebar-collapse, sidebar-mini
         <section class="sidebar">
             {% block sidebar_user %}
                 {% if app.user is not null and is_granted('IS_AUTHENTICATED_FULLY') %}
-                    {{ render(controller('AdminLTEBundle:Sidebar:userPanel')) }}
+                    {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\SidebarController::userPanelAction')) }}
                 {% endif %}
             {% endblock %}
 
             {% block sidebar_search %}
-                {{ render(controller('AdminLTEBundle:Sidebar:searchForm')) }}
+                {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\SidebarController::searchFormAction')) }}
             {% endblock %}
 
             {% block sidebar_nav %}
                 {% if admin_lte_context.knp_menu.enable %}
                     {% include '@AdminLTE/Sidebar/knp-menu.html.twig' %}
                 {% else %}
-                    {{ render(controller('AdminLTEBundle:Sidebar:menu', {'request':app.request})) }}
+                    {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\SidebarController::menuAction', {'request':app.request})) }}
                 {% endif %}
             {% endblock %}
         </section>
@@ -107,7 +107,7 @@ fixed, layout-boxed, layout-top-nav, sidebar-collapse, sidebar-mini
                 {% if admin_lte_context.knp_menu.enable %}
                     {% include '@AdminLTE/Breadcrumb/knp-breadcrumb.html.twig' %}
                 {% else %}
-                    {{ render(controller('AdminLTEBundle:Breadcrumb:breadcrumb', {'request':app.request})) }}
+                    {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\BreadcrumbController::breadcrumbAction', {'request':app.request})) }}
                 {% endif %}
             {% endblock %}
         </section>

--- a/Resources/views/layout/form-theme-base.html.twig
+++ b/Resources/views/layout/form-theme-base.html.twig
@@ -6,7 +6,7 @@
 #}
 
 {% block form_errors %}
-    {% filter spaceless %}
+    {% apply spaceless %}
         {% if errors|length > 0 %}
             <ul class="list-unstyled">
                 {% for error in errors %}
@@ -14,7 +14,7 @@
                 {% endfor %}
             </ul>
         {% endif %}
-    {% endfilter %}
+    {% endapply %}
 {% endblock form_errors %}
 
 {% block widget_attributes %}
@@ -42,13 +42,13 @@
 {% endblock widget_attributes %}
 
 {% block choice_widget_expanded %}
-    {% filter spaceless %}
+    {% apply spaceless %}
         <div {{ block('widget_container_attributes') }}>
             {% for child in form %}
                 {{ form_widget(child) }}
             {% endfor %}
         </div>
-    {% endfilter %}
+    {% endapply %}
 {% endblock choice_widget_expanded %}
 
 {% block choice_widget_collapsed %}
@@ -63,7 +63,7 @@
 
 {% block checkbox_widget %}
     <div class="checkbox">
-        {% filter spaceless %}
+        {% apply spaceless %}
             {% if not compound %}
                 {% set label_attr = label_attr|merge({'for': id}) %}
             {% endif %}
@@ -80,13 +80,13 @@
                 {{ label|trans({}, translation_domain) }}
             {% endif %}
             </label>
-        {% endfilter %}
+        {% endapply %}
     </div>
 {% endblock checkbox_widget %}
 
 {% block radio_widget %}
     <div class="radio">
-        {% filter spaceless %}
+        {% apply spaceless %}
             {% if not compound %}
                 {% set label_attr = label_attr|merge({'for': id}) %}
             {% endif %}
@@ -102,7 +102,7 @@
                 {{ label|trans({}, translation_domain) }}
             {% endif %}
             </label>
-        {% endfilter %}
+        {% endapply %}
     </div>
 {% endblock radio_widget %}
 

--- a/Resources/views/layout/form-theme-horizontal.html.twig
+++ b/Resources/views/layout/form-theme-horizontal.html.twig
@@ -6,7 +6,7 @@
 #}
 
 {% block form_errors %}
-    {% filter spaceless %}
+    {% apply spaceless %}
         {% if errors|length > 0 %}
             <ul class="list-unstyled">
                 {% for error in errors %}
@@ -14,7 +14,7 @@
                 {% endfor %}
             </ul>
         {% endif %}
-    {% endfilter %}
+    {% endapply %}
 {% endblock form_errors %}
 
 {% block widget_attributes %}
@@ -42,13 +42,13 @@
 {% endblock widget_attributes %}
 
 {% block choice_widget_expanded %}
-    {% filter spaceless %}
+    {% apply spaceless %}
         <div {{ block('widget_container_attributes') }}>
             {% for child in form %}
                 {{ form_widget(child) }}
             {% endfor %}
         </div>
-    {% endfilter %}
+    {% endapply %}
 {% endblock choice_widget_expanded %}
 
 {% block choice_widget_collapsed %}
@@ -63,7 +63,7 @@
 
 {% block checkbox_widget %}
     <div class="checkbox">
-        {% filter spaceless %}
+        {% apply spaceless %}
             {% if not compound %}
                 {% set label_attr = label_attr|merge({'for': id}) %}
             {% endif %}
@@ -80,13 +80,13 @@
                 {{ label|trans({}, translation_domain) }}
             {% endif %}
             </label>
-        {% endfilter %}
+        {% endapply %}
     </div>
 {% endblock checkbox_widget %}
 
 {% block radio_widget %}
     <div class="radio">
-        {% filter spaceless %}
+        {% apply spaceless %}
             {% if not compound %}
                 {% set label_attr = label_attr|merge({'for': id}) %}
             {% endif %}
@@ -102,7 +102,7 @@
                 {{ label|trans({}, translation_domain) }}
             {% endif %}
             </label>
-        {% endfilter %}
+        {% endapply %}
     </div>
 {% endblock radio_widget %}
 


### PR DESCRIPTION
## Description
This PR fixes a couple of deprecation notices that I experienced with Symfony 4.3.*
I have tested the changes with the demo project, I guess unittests are not needed because there were no functional changes. 

1. Changed the argument for twig function controller to suit the new format in following twig template:
- layout/default-layout.html.twig

2. Changed the "filter" tag to "apply" tag in following twig templates:
- Breadcrumb/knp-breadcrumb.html.twig
- layout/default-layout.html.twig
- layout/form-theme-base.html.twig 
- layout/form-theme-horizontal.html.twig
 
3. Changed the use statements of the following classes:
- Symfony\Component\EventDispatcher\Event **to** Symfony\Contracts\EventDispatcher\Event
- Symfony\Component\EventDispatcher\EventDispatcherInterface **to** Symfony\Contracts\EventDispatcher\EventDispatcherInterface

4. Changed the triggerMethod in class EmitterController so that the parameters are in the same order as EventDispatcherInterface::dispatch

5. Changed the call to triggerMethod to have the right arguments in the following file :
- Controller/NavbarController.php 

6. Change the call to EventDispatcherInterface::dispatch to have the right arguments in the following files:
- Controller/BreadcrumbController.php 
- Controller/EmitterController.php 
- Controller/NavbarController.php 
- Controller/SidebarController.php 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
