### PR TITLE
Added a block for the 'member since' field in Navbar/user.html.twig

### DIFF
--- a/Resources/docs/navbar_user.md
+++ b/Resources/docs/navbar_user.md
@@ -135,6 +135,22 @@ services:
             - { name: kernel.event_listener, event: theme.navbar_user, method: onShowUser }
 ```
 
+## Customizing the HTML output
+
+Considering you want to change the generated HTML of the user dropdown, you can simply overwrite the template.
+
+Create the file `templates/bundles/AdminLTEBundle/Navbar/user.html.twig` and add your own HTML.
+
+Or you can even replace some blocks inside the themes template by extending it:
+```twig
+{% extends "@!AdminLTE/Navbar/user.html.twig" %}
+{% block member_since %}
+    {# I do not want to display the member since information #}
+{% endblock %}
+```
+
+Right now, there is only the one block `member_since`, but if you need more: just drop a PR for new ones!
+
 ## Next steps
 
 Please go back to the [AdminLTE bundle documentation](README.md) to find out more about using the theme.

--- a/Resources/views/Navbar/user.html.twig
+++ b/Resources/views/Navbar/user.html.twig
@@ -13,7 +13,9 @@
             {{ macro.avatar(user.avatar, user.username) }}
             <p>
                 {{ user.name }} - {{ user.title }}
+                {% block member_since %}
                 <small>{{ 'Member since %date%'|trans({'%date%': user.memberSince|date('m.Y') }, 'AdminLTEBundle') }}</small>
+                {% endblock %}
             </p>
         </li>
         {% if links %}


### PR DESCRIPTION
## Description
Added the block 'member_since' around the user.memberSince markup in Navbar/user.html.twig

Fixes #79 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
