### PR TITLE
fix 4.1 deprecations which are bc safe

### DIFF
--- a/Resources/views/layout/default-layout.html.twig
+++ b/Resources/views/layout/default-layout.html.twig
@@ -50,16 +50,16 @@ fixed, layout-boxed, layout-top-nav, sidebar-collapse, sidebar-mini
                 <ul class="nav navbar-nav">
                     {% block navbar_start %}{% endblock %}
                     {% block navbar_messages %}
-                        {{ render(controller('AdminLTEBundle:Navbar:messages')) }}
+                        {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\NavbarController:messagesAction')) }}
                     {% endblock %}
                     {% block navbar_notifications %}
-                        {{ render(controller('AdminLTEBundle:Navbar:notifications')) }}
+                        {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\NavbarController:notificationsAction')) }}
                     {% endblock %}
                     {% block navbar_tasks %}
-                        {{ render(controller('AdminLTEBundle:Navbar:tasks')) }}
+                        {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\NavbarController:tasksAction')) }}
                     {% endblock %}
                     {% block navbar_user %}
-                        {{ render(controller('AdminLTEBundle:Navbar:user')) }}
+                        {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\NavbarController:userAction')) }}
                     {% endblock %}
                     {% block navbar_end %}{% endblock %}
                     {% block navbar_control_sidebar_toggle %}
@@ -78,19 +78,19 @@ fixed, layout-boxed, layout-top-nav, sidebar-collapse, sidebar-mini
         <section class="sidebar">
             {% block sidebar_user %}
                 {% if app.user is not null and is_granted('IS_AUTHENTICATED_FULLY') %}
-                    {{ render(controller('AdminLTEBundle:Sidebar:userPanel')) }}
+                    {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\SidebarController:userPanelAction')) }}
                 {% endif %}
             {% endblock %}
 
             {% block sidebar_search %}
-                {{ render(controller('AdminLTEBundle:Sidebar:searchForm')) }}
+                {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\SidebarController:searchFormAction')) }}
             {% endblock %}
 
             {% block sidebar_nav %}
                 {% if admin_lte_context.knp_menu.enable %}
                     {% include '@AdminLTE/Sidebar/knp-menu.html.twig' %}
                 {% else %}
-                    {{ render(controller('AdminLTEBundle:Sidebar:menu', {'request':app.request})) }}
+                    {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\SidebarController:menuAction', {'request':app.request})) }}
                 {% endif %}
             {% endblock %}
         </section>
@@ -107,7 +107,7 @@ fixed, layout-boxed, layout-top-nav, sidebar-collapse, sidebar-mini
                 {% if admin_lte_context.knp_menu.enable %}
                     {% include '@AdminLTE/Breadcrumb/knp-breadcrumb.html.twig' %}
                 {% else %}
-                    {{ render(controller('AdminLTEBundle:Breadcrumb:breadcrumb', {'request':app.request})) }}
+                    {{ render(controller('KevinPapst\\AdminLTEBundle\\Controller\\BreadcrumbController:breadcrumbAction', {'request':app.request})) }}
                 {% endif %}
             {% endblock %}
         </section>


### PR DESCRIPTION
## Description

Fixes deprecation messages like 
```
User Deprecated: Referencing controllers with AdminLTEBundle:Navbar:messages is deprecated since Symfony 4.1, use "KevinPapst\AdminLTEBundle\Controller\NavbarController::messagesAction" instead
```

See also #80 by @RickJelier 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)