### PR TITLE
Feat/sf43 event dispatcher behavior compatibility

### DIFF
--- a/Controller/EmitterController.php
+++ b/Controller/EmitterController.php
@@ -9,10 +9,12 @@
 
 namespace KevinPapst\AdminLTEBundle\Controller;
 
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class EmitterController extends AbstractController
 {
@@ -26,7 +28,11 @@ class EmitterController extends AbstractController
      */
     public function __construct(EventDispatcherInterface $dispatcher)
     {
-        $this->eventDispatcher = $dispatcher;
+        if (Kernel::MINOR_VERSION < 3) {
+            $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
+        } else {
+            $this->eventDispatcher = $dispatcher;
+        }
     }
 
     /**

--- a/Helper/Symfony/Component/LegacyEventDispatcherProxy.php
+++ b/Helper/Symfony/Component/LegacyEventDispatcherProxy.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+
+/**
+ * A helper class to provide BC/FC with the legacy signature of EventDispatcherInterface::dispatch().
+ *
+ * This class should be deprecated in Symfony 5.1
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class LegacyEventDispatcherProxy implements EventDispatcherInterface
+{
+    private $dispatcher;
+
+    public static function decorate(?ContractsEventDispatcherInterface $dispatcher): ?ContractsEventDispatcherInterface
+    {
+        if (null === $dispatcher) {
+            return null;
+        }
+        $r = new \ReflectionMethod($dispatcher, 'dispatch');
+        $param2 = $r->getParameters()[1] ?? null;
+
+        if (!$param2 || !$param2->hasType() || $param2->getType()->isBuiltin()) {
+            return $dispatcher;
+        }
+
+        @trigger_error(sprintf('The signature of the "%s::dispatch()" method should be updated to "dispatch($event, string $eventName = null)", not doing so is deprecated since Symfony 4.3.', $r->class), E_USER_DEPRECATED);
+
+        $self = new self();
+        $self->dispatcher = $dispatcher;
+
+        return $self;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|null $eventName
+     *
+     * @return object
+     */
+    public function dispatch($event/*, string $eventName = null*/)
+    {
+        $eventName = 1 < \func_num_args() ? func_get_arg(1) : null;
+
+        if (\is_object($event)) {
+            $eventName = $eventName ?? \get_class($event);
+        } elseif (\is_string($event) && (null === $eventName || $eventName instanceof Event)) {
+            @trigger_error(sprintf('Calling the "%s::dispatch()" method with the event name as the first argument is deprecated since Symfony 4.3, pass it as the second argument and provide the event object as the first argument instead.', ContractsEventDispatcherInterface::class), E_USER_DEPRECATED);
+            $swap = $event;
+            $event = $eventName ?? new Event();
+            $eventName = $swap;
+        } else {
+            throw new \TypeError(sprintf('Argument 1 passed to "%s::dispatch()" must be an object, %s given.', ContractsEventDispatcherInterface::class, \is_object($event) ? \get_class($event) : \gettype($event)));
+        }
+
+        $listeners = $this->getListeners($eventName);
+        $stoppable = $event instanceof Event || $event instanceof ContractsEvent || $event instanceof StoppableEventInterface;
+
+        foreach ($listeners as $listener) {
+            if ($stoppable && $event->isPropagationStopped()) {
+                break;
+            }
+            $listener($event, $eventName, $this);
+        }
+
+        return $event;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addListener($eventName, $listener, $priority = 0)
+    {
+        return $this->dispatcher->addListener($eventName, $listener, $priority);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSubscriber(EventSubscriberInterface $subscriber)
+    {
+        return $this->dispatcher->addSubscriber($subscriber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeListener($eventName, $listener)
+    {
+        return $this->dispatcher->removeListener($eventName, $listener);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeSubscriber(EventSubscriberInterface $subscriber)
+    {
+        return $this->dispatcher->removeSubscriber($subscriber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListeners($eventName = null)
+    {
+        return $this->dispatcher->getListeners($eventName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->dispatcher->getListenerPriority($eventName, $listener);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasListeners($eventName = null)
+    {
+        return $this->dispatcher->hasListeners($eventName);
+    }
+
+    /**
+     * Proxies all method calls to the original event dispatcher.
+     */
+    public function __call($method, $arguments)
+    {
+        return $this->dispatcher->{$method}(...$arguments);
+    }
+}

--- a/Helper/Symfony/Contracts/Event.php
+++ b/Helper/Symfony/Contracts/Event.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\EventDispatcher;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+
+if (interface_exists(StoppableEventInterface::class)) {
+    /**
+     * Event is the base class for classes containing event data.
+     *
+     * This class contains no event data. It is used by events that do not pass
+     * state information to an event handler when an event is raised.
+     *
+     * You can call the method stopPropagation() to abort the execution of
+     * further listeners in your event listener.
+     *
+     * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+     * @author Jonathan Wage <jonwage@gmail.com>
+     * @author Roman Borschel <roman@code-factory.org>
+     * @author Bernhard Schussek <bschussek@gmail.com>
+     * @author Nicolas Grekas <p@tchwork.com>
+     */
+    class Event implements StoppableEventInterface
+    {
+        private $propagationStopped = false;
+
+        /**
+         * Returns whether further event listeners should be triggered.
+         */
+        public function isPropagationStopped(): bool
+        {
+            return $this->propagationStopped;
+        }
+
+        /**
+         * Stops the propagation of the event to further event listeners.
+         *
+         * If multiple event listeners are connected to the same event, no
+         * further event listener will be triggered once any trigger calls
+         * stopPropagation().
+         */
+        public function stopPropagation(): void
+        {
+            $this->propagationStopped = true;
+        }
+    }
+} else {
+    /**
+     * Event is the base class for classes containing event data.
+     *
+     * This class contains no event data. It is used by events that do not pass
+     * state information to an event handler when an event is raised.
+     *
+     * You can call the method stopPropagation() to abort the execution of
+     * further listeners in your event listener.
+     *
+     * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+     * @author Jonathan Wage <jonwage@gmail.com>
+     * @author Roman Borschel <roman@code-factory.org>
+     * @author Bernhard Schussek <bschussek@gmail.com>
+     * @author Nicolas Grekas <p@tchwork.com>
+     */
+    class Event
+    {
+        private $propagationStopped = false;
+
+        /**
+         * Returns whether further event listeners should be triggered.
+         */
+        public function isPropagationStopped(): bool
+        {
+            return $this->propagationStopped;
+        }
+
+        /**
+         * Stops the propagation of the event to further event listeners.
+         *
+         * If multiple event listeners are connected to the same event, no
+         * further event listener will be triggered once any trigger calls
+         * stopPropagation().
+         */
+        public function stopPropagation(): void
+        {
+            $this->propagationStopped = true;
+        }
+    }
+}

--- a/Helper/Symfony/Contracts/EventDispatcherInterface.php
+++ b/Helper/Symfony/Contracts/EventDispatcherInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\EventDispatcher;
+
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
+
+if (interface_exists(PsrEventDispatcherInterface::class)) {
+    /**
+     * Allows providing hooks on domain-specific lifecycles by dispatching events.
+     */
+    interface EventDispatcherInterface extends PsrEventDispatcherInterface
+    {
+        /**
+         * Dispatches an event to all registered listeners.
+         *
+         * For BC with Symfony 4, the $eventName argument is not declared explicitly on the
+         * signature of the method. Implementations that are not bound by this BC constraint
+         * MUST declare it explicitly, as allowed by PHP.
+         *
+         * @param object      $event     The event to pass to the event handlers/listeners
+         * @param string|null $eventName The name of the event to dispatch. If not supplied,
+         *                               the class of $event should be used instead.
+         *
+         * @return object The passed $event MUST be returned
+         */
+        public function dispatch($event/*, string $eventName = null*/);
+    }
+} else {
+    /**
+     * Allows providing hooks on domain-specific lifecycles by dispatching events.
+     */
+    interface EventDispatcherInterface
+    {
+        /**
+         * Dispatches an event to all registered listeners.
+         *
+         * For BC with Symfony 4, the $eventName argument is not declared explicitly on the
+         * signature of the method. Implementations that are not bound by this BC constraint
+         * MUST declare it explicitly, as allowed by PHP.
+         *
+         * @param object      $event     The event to pass to the event handlers/listeners
+         * @param string|null $eventName The name of the event to dispatch. If not supplied,
+         *                               the class of $event should be used instead.
+         *
+         * @return object The passed $event MUST be returned
+         */
+        public function dispatch($event/*, string $eventName = null*/);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,10 @@
         "friendsofsymfony/user-bundle": "Allows easy user management and security support"
     },
     "autoload": {
-        "psr-4": { "KevinPapst\\AdminLTEBundle\\": "" }
+        "psr-4": {
+            "Symfony\\": "Helper/Symfony/",
+            "KevinPapst\\AdminLTEBundle\\": ""
+        }
     },
     "scripts": {
         "tests": "vendor/bin/phpunit Tests/",


### PR DESCRIPTION
## Description
To solve issue #85 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [X] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)

## Test Info

| Component  | Version |
| ------------- | ------------- |
| Symfony version  | 4.3.4 and 4.2.11  |
| AdminLTEBundle  | 2.8.5  |
| AdminLTEBundle-Demo  | 2.7.1  |
| Operating System  | Linux  |

TestCases:

* https://github.com/kevinpapst/AdminLTEBundle/blob/master/Controller/NavbarController.php#L77
Both signatures 
```
$listEvent = $this->getDispatcher()->dispatch(ThemeEvents::THEME_MESSAGES, new MessageListEvent($max));
// and
$listEvent = $this->getDispatcher()->dispatch(new MessageListEvent($max));
```
For second signature (Symfony 4.3 new behavior) we have as explained in https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching to change a little AdminLTEBundle-Demo as follow  (example) : 

```
# src/EventSubscriber/MessageSubscriber.php

use KevinPapst\AdminLTEBundle\Event\MessageListEvent;

class MessageSubscriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            ThemeEvents::THEME_MESSAGES => ['onMessages', 100],
            MessageListEvent::class =>  ['onMessages', 100],
        ];
    }
}
```

I'll continue more tests tomorrow morning, but the goal seams reached. 
@kevinpapst Tell me if you're agree. Especially about symfony elements copied (from 4.3) in `Helper/Symony` folder 