### PR TITLE
Prevent usage of the js datepicker, when using html5 fields

### DIFF
--- a/Resources/views/layout/form-theme-base.html.twig
+++ b/Resources/views/layout/form-theme-base.html.twig
@@ -146,12 +146,14 @@
                 <div class="input-group-addon add-on">
                     <i class="far fa-clock"></i>
                 </div>
-                {% if attr.class is defined %}
-                    {% set class = attr.class ~ ' timepicker' %}
-                {% else %}
-                    {% set class = ' timepicker' %}
+                {% if type is not defined or type != 'time' %}
+                    {% if attr.class is defined %}
+                        {% set class = attr.class ~ ' timepicker' %}
+                    {% else %}
+                        {% set class = ' timepicker' %}
+                    {% endif %}
+                    {% set attr = attr|merge({'class' : class, 'data-timepicker':'on'}) %}
                 {% endif %}
-                {% set attr = attr|merge({'class' : class, 'data-timepicker':'on'}) %}
                 {{ block('form_widget_simple') }}
             </div>
         </div>

--- a/Resources/views/layout/form-theme-base.html.twig
+++ b/Resources/views/layout/form-theme-base.html.twig
@@ -113,7 +113,7 @@
                 <i class="far fa-calendar-alt"></i>
             </div>
 
-            {% if type is not defined or type == 'text' %}
+            {% if type is not defined or type != 'date' %}
                 {% if attr.class is defined %}
                     {% set class = attr.class ~ ' timepicker' %}
                 {% else %}

--- a/Resources/views/layout/form-theme-base.html.twig
+++ b/Resources/views/layout/form-theme-base.html.twig
@@ -113,12 +113,14 @@
                 <i class="far fa-calendar-alt"></i>
             </div>
 
-            {% if attr.class is defined %}
-                {% set class = attr.class ~ ' timepicker' %}
-            {% else %}
-                {% set class = ' timepicker' %}
+            {% if type is not defined or type == 'text' %}
+                {% if attr.class is defined %}
+                    {% set class = attr.class ~ ' timepicker' %}
+                {% else %}
+                    {% set class = ' timepicker' %}
+                {% endif %}
+                {% set attr = attr|merge({'class' : class, 'data-datepickerenable':'on'}) %}
             {% endif %}
-            {% set attr = attr|merge({'class' : class, 'data-datepickerenable':'on'}) %}
 
             {{ block('form_widget_simple') }}
         </div>

--- a/Resources/views/layout/form-theme-horizontal.html.twig
+++ b/Resources/views/layout/form-theme-horizontal.html.twig
@@ -146,12 +146,14 @@
                 <div class="input-group-addon add-on">
                     <i class="far fa-clock"></i>
                 </div>
-                {% if attr.class is defined %}
-                    {% set class = attr.class ~ ' timepicker' %}
-                {% else %}
-                    {% set class = ' timepicker' %}
+                {% if type is not defined or type != 'time' %}
+                    {% if attr.class is defined %}
+                        {% set class = attr.class ~ ' timepicker' %}
+                    {% else %}
+                        {% set class = ' timepicker' %}
+                    {% endif %}
+                    {% set attr = attr|merge({'class' : class, 'data-timepicker':'on'}) %}
                 {% endif %}
-                {% set attr = attr|merge({'class' : class, 'data-timepicker':'on'}) %}
                 {{ block('form_widget_simple') }}
             </div>
         </div>

--- a/Resources/views/layout/form-theme-horizontal.html.twig
+++ b/Resources/views/layout/form-theme-horizontal.html.twig
@@ -113,7 +113,7 @@
                 <i class="far fa-calendar-alt"></i>
             </div>
 
-            {% if type is not defined or type == 'text' %}
+            {% if type is not defined or type != 'date' %}
                 {% if attr.class is defined %}
                     {% set class = attr.class ~ ' timepicker' %}
                 {% else %}

--- a/Resources/views/layout/form-theme-horizontal.html.twig
+++ b/Resources/views/layout/form-theme-horizontal.html.twig
@@ -113,12 +113,14 @@
                 <i class="far fa-calendar-alt"></i>
             </div>
 
-            {% if attr.class is defined %}
-                {% set class = attr.class ~ ' timepicker' %}
-            {% else %}
-                {% set class = ' timepicker' %}
+            {% if type is not defined or type == 'text' %}
+                {% if attr.class is defined %}
+                    {% set class = attr.class ~ ' timepicker' %}
+                {% else %}
+                    {% set class = ' timepicker' %}
+                {% endif %}
+                {% set attr = attr|merge({'class' : class, 'data-datepickerenable':'on'}) %}
             {% endif %}
-            {% set attr = attr|merge({'class' : class, 'data-datepickerenable':'on'}) %}
 
             {{ block('form_widget_simple') }}
         </div>


### PR DESCRIPTION
When i use the default DateType with html5, the js datepicker and the native datepicker interfere with each other (overlap). The fix assumes, if the field type is not "text", the native (browser) datepicker should be used.

I'm not sure if the same should be applied to the time_widget?