### PR TITLE
do not show box_footer if empty

### DIFF
--- a/Resources/views/Widgets/box-widget.html.twig
+++ b/Resources/views/Widgets/box-widget.html.twig
@@ -38,8 +38,15 @@
     </div>
     {% endif %}
     <div class="box-body{% if block('box_body_class') is defined %} {{ block('box_body_class') }}{% endif %}">{{ block('box_body') }}</div>
-    {% if _footer %}
-        <div class="box-footer">{% if block('box_footer') is defined %}{{ block('box_footer') }}{% endif %}</div>
+    {% if _footer and block('box_footer') is defined %}
+        {# 
+            If there is a form in the block_footer, it will be rendered when checking "is not empty". 
+            Therefor we have to cache the output first and then perform the checks. 
+        #}
+        {% set boxFooter = block('box_footer') %}
+        {% if boxFooter is not empty %}
+            <div class="box-footer">{{ boxFooter|raw }}</div>
+        {% endif %}
     {% endif %}
 </div>
 {% if block('box_after') is defined %}{{ block('box_after') }}{% endif %}


### PR DESCRIPTION
## Description

A minor change: if the block `box_footer` was declared, but left empty, there was an empty white row visible.
This is now gone if the output is empty.

Something like that is now possible without running into the problem of an empty white row:
```
{% block box_footer -%}
  {% if false %}
    Hello world!
  {% endif %}
{%- endblock %}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
