### PR TITLE
add method to remove MenuItem from menu

### DIFF
--- a/Event/MenuEvent.php
+++ b/Event/MenuEvent.php
@@ -68,7 +68,6 @@ abstract class MenuEvent extends ThemeEvent
      */
     public function removeItem($item): MenuEvent
     {
-        $item = new MenuItem();
         if ($item instanceof MenuItemInterface && isset($this->menuRootItems[$item->getIdentifier()])) {
             unset($this->menuRootItems[$item->getIdentifier()]);
         } elseif (is_string($item) && isset($this->menuRootItems[$item])) {

--- a/Event/MenuEvent.php
+++ b/Event/MenuEvent.php
@@ -63,6 +63,22 @@ abstract class MenuEvent extends ThemeEvent
     }
 
     /**
+     * @param MenuItemInterface|MenuItem|string $item
+     * @return MenuEvent
+     */
+    public function removeItem($item): MenuEvent
+    {
+        $item = new MenuItem();
+        if ($item instanceof MenuItemInterface && isset($this->menuRootItems[$item->getIdentifier()])) {
+            unset($this->menuRootItems[$item->getIdentifier()]);
+        } elseif (is_string($item) && isset($this->menuRootItems[$item])) {
+            unset($this->menuRootItems[$item]);
+        }
+
+        return $this;
+    }
+
+    /**
      * @param string $id
      * @return MenuItemInterface|MenuItem|null
      */


### PR DESCRIPTION
Contribution to #111 

As I haven't worked with KnpMenu, I've only added the suggested Code from the Issue. 

Is it correct to detect the MenuItem by `$name`? 

And the KnpMenuBundle is no requirement, so I need to detect by [`Knp\Menu\MenuItem`](https://github.com/KnpLabs/KnpMenu/blob/master/src/Knp/Menu/MenuItem.php) class as string?

```php

if (is_subclass_of($item, 'Knp\Menu\MenuItem') && isset($this->menuRootItems[$item->getName()])) {
            unset($this->menuRootItems[$item->getName()]);
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
