### PR TITLE
Add trans 'twig filter' to label items

### DIFF
--- a/Resources/views/Breadcrumb/knp-breadcrumb.html.twig
+++ b/Resources/views/Breadcrumb/knp-breadcrumb.html.twig
@@ -9,7 +9,7 @@
             {% for item in items %}
                 {% if not loop.first %}
                 <li class="{{ loop.last ? 'active' : '' }}">
-                    <a href="{{ item.uri }}">{{ item.label }}</a>
+                    <a href="{{ item.uri }}">{{ item.label | trans }}</a>
                 </li>
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
## Description
Add to the breadcrumb items label, the twig trans filter for auto translation if founded

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [X] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
