### PR TITLE
Add the ability to add badges on label (KNP-based) 

### DIFF
--- a/Resources/docs/knp_menu.md
+++ b/Resources/docs/knp_menu.md
@@ -71,12 +71,24 @@ class KnpMenuBuilderSubscriber implements EventSubscriberInterface
         $menu->addChild('blogId', [
             'route' => 'item_symfony_route',
             'label' => 'Blog',
-            'childOptions' => $event->getChildOptions()
+            'childOptions' => $event->getChildOptions(),
+            'extras' => [
+                'badge' => [
+                    'color' => 'yellow',
+                    'value' => 4,
+                ],
+            ],
         ])->setLabelAttribute('icon', 'fas fa-tachometer-alt');
         
         $menu->getChild('blogId')->addChild('ChildOneItemId', [
             'route' => 'child_1_route',
             'label' => 'ChildOneDisplayName',
+            'extras' => [
+                'badges' => [
+                    [ 'value' => 6, 'color' => 'blue' ],
+                    [ 'value' => 5, ],
+                ],
+            ],
             'childOptions' => $event->getChildOptions()
         ])->setLabelAttribute('icon', 'fas fa-rss-square');
         

--- a/Resources/views/Partials/_menu.html.twig
+++ b/Resources/views/Partials/_menu.html.twig
@@ -6,12 +6,32 @@
         <span>{% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ item.label|trans|raw }}{% else %}{{ item.label|trans }}{% endif %}</span>
     {% endif %}
     {% if item.labelAttribute('data-image') %}<img src="{{ item.labelAttribute('data-image') }}" alt="{{ item.name }}" class="menu-thumbnail"/>{% endif %}
+    
+    {% import _self as selfMacros %}
     {% if item.hasChildren and options.depth is not same as(0) and item.displayChildren %}
         <span class="pull-right-container">
+            {{ selfMacros.badges(item) }}
             <i class="fas fa-angle-left pull-right"></i>
         </span>
+    {% else %}
+        {{ selfMacros.badges(item) }}
     {% endif %}
 {% endblock %}
+
+{% macro badges(item) %}
+    {% import _self as selfMacros %}
+    {% if item.getExtra('badge') is not null %}
+        {{ selfMacros.badge(item.getExtra('badge')) }}
+    {% elseif item.getExtra('badges') is not null %}
+        {% for badge in item.getExtra('badges') %}
+            {{ selfMacros.badge(badge) }}
+        {% endfor %}
+    {% endif %}
+{% endmacro %}
+
+{% macro badge(badge) %}
+    <small class="label pull-right bg-{{ badge.color|default('green') }}">{{ badge.value }}</small>
+{% endmacro %}
 
 {% block list %}
     {% if item.hasChildren and options.depth is not same as(0) and item.displayChildren %}


### PR DESCRIPTION
Allows you to add extra information on label (pull-right content)

![image](https://user-images.githubusercontent.com/4682556/78116205-42585d80-7404-11ea-8816-d2905517d7ba.png)


## Description
It doesn't seem to be the right way of doing it, but it can be a first implementation.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
