### PR TITLE
remove duplicate call to sass loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,9 +22,6 @@ Encore
     // generate only two files: app.js and app.css
     .addEntry('adminlte', './Resources/assets/admin-lte.js')
 
-    // enable sass/scss parser
-    .enableSassLoader()
-
     // show OS notifications when builds finish/fail
     .enableBuildNotifications()
 
@@ -34,6 +31,7 @@ Encore
     // for "legacy" applications that require $/jQuery as a global variable
     .autoProvidejQuery()
 
+    // enable sass/scss parser
     // see https://symfony.com/doc/current/frontend/encore/bootstrap.html
     .enableSassLoader(function(sassOptions) {}, {
         resolveUrlLoader: false


### PR DESCRIPTION
## Description

Remove the first call (without parameters).


## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [X ] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
