### PR TITLE
Set knp_menu.enable as a boolean instead of scalar

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -114,7 +114,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->addDefaultsIfNotSet()
             ->children()
-                ->scalarNode('enable')
+                ->booleanNode('enable')
                     ->defaultFalse()
                     ->info('')
                 ->end()


### PR DESCRIPTION
Setting something else than a boolean ends in an exception about the next element, "main_menu"

    An exception has been thrown during the rendering of a template ("The menu "adminlte_main" is not defined.").

With the enable attribute as a boolean, the exception is now understandable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
