### PR TITLE
inlined some FOSUserBundle translations to reduce coupling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Total Downloads](https://poser.pugx.org/kevinpapst/adminlte-bundle/downloads)](https://packagist.org/packages/kevinpapst/adminlte-bundle)
 [![License](https://poser.pugx.org/kevinpapst/adminlte-bundle/license)](LICENSE)
 
-# AdminLTE Bundle for Symfony 4
+# AdminLTE Bundle for Symfony
 
 This repository contains an upgraded version of the AvanzuAdminThemeBundle, bringing the AdminLTE theme to Symfony 4.
 
@@ -16,12 +16,12 @@ This repository contains an upgraded version of the AvanzuAdminThemeBundle, brin
 ### Minimum requirements
 
 - Symfony 4.3
-- PHP 7.2 (untested with 8)
+- PHP > 7.2
 - Twig 2.0
 
 **Compatibility:**
 
-Version 3.x should be compatible with Symfony 5, [please leave your feedback](https://github.com/kevinpapst/AdminLTEBundle/issues/144).
+Version 3.x should be compatible with Symfony 5 and PHP 8, [please leave your feedback](https://github.com/kevinpapst/AdminLTEBundle/issues/144).
 
 - Version 3.x is only compatible with Symfony >= 4.3
 - Version 2.x of this bundle is compatible with Symfony < 4.3

--- a/Resources/translations/AdminLTEBundle.ar.xliff
+++ b/Resources/translations/AdminLTEBundle.ar.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>الخروج</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>تسجيل</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>ملفك الشخصي</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>اسم المستخدم</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>إسم المستخدم او البريد الالكتروني</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -77,6 +85,10 @@
             <trans-unit id="%progress%% Complete">
                 <source>%progress%% Complete</source>
                 <target>%progress%% منجز</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>تهانينا %username%، لقد تم تفعيل حسابك.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.cs.xliff
+++ b/Resources/translations/AdminLTEBundle.cs.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Odhlásit se</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registrovat se</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Profil</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Uživatelské jméno</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Uživatelské jméno nebo e-mail</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Toto je povinné pole</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Gratulujeme, %username%, Váš účet je nyní aktivní.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.da.xliff
+++ b/Resources/translations/AdminLTEBundle.da.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Log ud</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registrer</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Din profil</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Brugernavn</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Brugernavn eller e-mailadresse</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Dette er et obligatorisk felt</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Tillykke %username%, din konto er nu aktiveret</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.de.xliff
+++ b/Resources/translations/AdminLTEBundle.de.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Abmelden</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registrieren</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Dein Profil</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Benutzername</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Benutzername oder E-Mail-Adresse</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Dies ist ein Pflichtfeld</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Glückwunsch %username%, Ihr Benutzerkonto ist jetzt bestätigt.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.el.xliff
+++ b/Resources/translations/AdminLTEBundle.el.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Αποσύνδεση</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Εγγραφή</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Το προφίλ μου</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Όνομα Χρήστη</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Επαναφορά του κωδικού πρόσβασης</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Αυτό είναι υποχρεωτικό πεδίο</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Συγχαρητήρια %username%, ο λογαριασμός μόλις ενεργοποιήθηκε.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.en.xliff
+++ b/Resources/translations/AdminLTEBundle.en.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Logout</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Register</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Your profile</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Username</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Username or email address</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>This is a mandatory field</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Congratulations %username%, your account is now activated.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.eo.xliff
+++ b/Resources/translations/AdminLTEBundle.eo.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Elsaluti</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registriĝi</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Via profilo</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Uzantnomo</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Uzantnomo aŭ retpoŝtadreso</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Tio ĉi estas deviga kampo</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Gratulon %username%, via konto estas aktiva.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.es.xliff
+++ b/Resources/translations/AdminLTEBundle.es.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Cerrar sesión</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registrar</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Tu perfil</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Nombre de usuario</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Nombre de usuario o correo electrónico</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Este es un campo obligatorio</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Felicidades %username%, tu cuenta está ahora confirmada.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.eu.xliff
+++ b/Resources/translations/AdminLTEBundle.eu.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Saioa itxi</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Izena eman</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Nire kontua</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Erabiltzailea</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Erabiltzaile izena</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Derrigorezko sarrera</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Zorionak %username%, zure kontua aktibatua dago.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.fi.xliff
+++ b/Resources/translations/AdminLTEBundle.fi.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target state="translated">Kirjaudu ulos</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Luo tunnus</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target state="translated">Profiili</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target state="translated">Käyttäjätunnus</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Käyttäjätunnus tai sähköpostiosoite</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target state="translated">Tämä on pakollinen kenttä</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Onnittelut %username%, tunnuksesi on nyt aktivoitu.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.fr.xliff
+++ b/Resources/translations/AdminLTEBundle.fr.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Déconnexion</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Créer un compte</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Mon profil</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Identifiant</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Nom d'utilisateur ou adresse e-mail</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Ce champ est obligatoire</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Félicitations %username%, votre compte est maintenant activé.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.he.xliff
+++ b/Resources/translations/AdminLTEBundle.he.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>התנתק</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>הרשם</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>הפרופיל שלך</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>שם משתמש</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>שם משתמש או דואר אלקטרוני</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>זהו שדה חובה</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>ברוכים הבאים %username%, חשבון שלך הופעל.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.it.xliff
+++ b/Resources/translations/AdminLTEBundle.it.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Disconnetti</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registra</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Il tuo profilo</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Nome utente</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Username o indirizzo email</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -77,6 +85,10 @@
             <trans-unit id="%progress%% Complete">
                 <source>%progress%% Complete</source>
                 <target>%progress%% completato</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Congratulazioni %username%, il tuo account è confermato.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.ja.xliff
+++ b/Resources/translations/AdminLTEBundle.ja.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>ログアウトする</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>登録</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>あなたのプロフィール</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>ユーザー名</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>ユーザー名またはメールアドレス</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>これは必須項目です</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>%username% さんのアカウントの確認が完了しました。</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.nl.xliff
+++ b/Resources/translations/AdminLTEBundle.nl.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target state="translated">Uitloggen</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registreer</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target state="translated">Profiel</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target state="translated">Gebruikersnaam</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Gebruikersnaam of e-mailadres</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target state="translated">Dit is een verplicht veld</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Gefeliciteerd %username%, uw account is nu geactiveerd.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.pl.xliff
+++ b/Resources/translations/AdminLTEBundle.pl.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Logout</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Zarejestruj</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Twój profil</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Nazwa użytkownika</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Nazwa użytkownika lub e-mail</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>To pole jest obowiązkowe</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Gratulacje %username%, Twoje konto zostało aktywowane.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.pt_BR.xliff
+++ b/Resources/translations/AdminLTEBundle.pt_BR.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Sair</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registrar</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Meu perfil</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Usuário</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Usuário ou email</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Este é um campo obrigatório</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Parabéns, %username%. A sua conta foi ativada.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.ro.xliff
+++ b/Resources/translations/AdminLTEBundle.ro.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Deconectare</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Înregistrează-te</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Profilul tău</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Nume de utilizator</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Numele de utilizator sau adresa de email</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Acesta este un câmp obligatoriu</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Felicitări %username%, contul tău a fost activat.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.ru.xliff
+++ b/Resources/translations/AdminLTEBundle.ru.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Logout</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Зарегистрироваться</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Your profile</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Имя пользователя</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Имя пользователя или электронная почта</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -77,6 +85,10 @@
             <trans-unit id="%progress%% Complete">
                 <source>%progress%% Complete</source>
                 <target>%progress%% completed</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Поздравляем %username%, ваш аккаунт подтвержден.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.sk.xliff
+++ b/Resources/translations/AdminLTEBundle.sk.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Odhlásiť sa</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registrácia</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Profil</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Používateľ</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Používateľské meno alebo emailová adresa</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Toto pole je povinné</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Gratulujeme %username%, Vaše konto bolo aktivované.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.sv.xliff
+++ b/Resources/translations/AdminLTEBundle.sv.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target state="translated">logga ut</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Registrera</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target state="translated">Din profil</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target state="translated">Användarnamn</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Användarnamn eller epost-adress</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target state="translated">Detta är ett obligatoriskt fält</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Grattis %username%, ditt konto är nu aktiverat.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.tr.xliff
+++ b/Resources/translations/AdminLTEBundle.tr.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>Çıkış</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>Kayıt ol</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>Profilim</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>Kullanıcı adı</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>Kullanıcı adı ya da e-posta adresi</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>Zorunlu alan</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>Tebrikler %username%. Hesabınız şu anda aktifleştirildi.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/AdminLTEBundle.zh_CN.xliff
+++ b/Resources/translations/AdminLTEBundle.zh_CN.xliff
@@ -22,6 +22,10 @@
                 <source>Sign out</source>
                 <target>注销</target>
             </trans-unit>
+            <trans-unit id="Register">
+                <source>Register</source>
+                <target>注册</target>
+            </trans-unit>
             <trans-unit id="Profile">
                 <source>Profile</source>
                 <target>个人资料</target>
@@ -33,6 +37,10 @@
             <trans-unit id="Username">
                 <source>Username</source>
                 <target>用户名</target>
+            </trans-unit>
+            <trans-unit id="Username or email address">
+                <source>Username or email address</source>
+                <target>用户名或邮箱</target>
             </trans-unit>
             <trans-unit id="Password">
                 <source>Password</source>
@@ -81,6 +89,10 @@
             <trans-unit id="This is a mandatory field">
                 <source>This is a mandatory field</source>
                 <target>该处为必填项</target>
+            </trans-unit>
+            <trans-unit id="registration.confirmed">
+                <source>registration.confirmed</source>
+                <target>%username%，恭喜你，你的帐户已启用！</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/views/FOSUserBundle/Registration/confirmed.html.twig
+++ b/Resources/views/FOSUserBundle/Registration/confirmed.html.twig
@@ -4,7 +4,7 @@
 
 {% block login_form %}
     {% block fos_user_content %}
-        <p>{{ 'registration.confirmed'|trans({'%username%': user.username}, 'FOSUserBundle') }}</p>
+        <p>{{ 'registration.confirmed'|trans({'%username%': user.username}, 'AdminLTEBundle') }}</p>
     {% endblock fos_user_content %}
 {% endblock %}
 

--- a/Resources/views/FOSUserBundle/Registration/register.html.twig
+++ b/Resources/views/FOSUserBundle/Registration/register.html.twig
@@ -7,12 +7,11 @@
 {% endblock %}
 
 {% block login_form %}
-    {% trans_default_domain 'FOSUserBundle' %}
     {% form_theme form '@AdminLTE/layout/form-theme-security.html.twig' %}
     {{ form_start(form, {'method': 'post', 'action': path('fos_user_registration_register'), 'attr': {'class': 'fos_user_registration_register'}}) }}
     {{ form_widget(form) }}
     <div class="form-group">
-        <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'registration.submit'|trans }}</button>
+        <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'Register'|trans({}, 'AdminLTEBundle') }}</button>
     </div>
     {{ form_end(form) }}
 {% endblock %}

--- a/Resources/views/FOSUserBundle/Resetting/request.html.twig
+++ b/Resources/views/FOSUserBundle/Resetting/request.html.twig
@@ -7,16 +7,14 @@
 {% endblock %}
 
 {% block login_form %}
-    {% trans_default_domain 'FOSUserBundle' %}
-
     <form action="{{ path('fos_user_resetting_send_email') }}" method="POST" class="fos_user_resetting_request">
         <div class="form-group has-feedback">
-            <input type="text" id="username" name="username" required="required" class="form-control" placeholder="{{ 'resetting.request.username'|trans }}">
+            <input type="text" id="username" name="username" required="required" class="form-control" placeholder="{{ 'Username or email address'|trans({}, 'AdminLTEBundle') }}">
             <span class="glyphicon glyphicon-envelope form-control-feedback"></span>
         </div>
         <div class="row">
             <div class="col-xs-12">
-            <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'resetting.request.submit'|trans }}</button>
+            <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'Reset your password'|trans({}, 'AdminLTEBundle') }}</button>
             </div>
         </div>
     </form>

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,11 +2,15 @@
 
 ## From v3 to v4 (unreleased)
 
+Read the changelogs at https://github.com/kevinpapst/AdminLTEBundle/releases
+
 Removed all Controller: already replaced with Twig functions for performance reasons in v3. 
 Templates will be now included directly.
 Check that overwritten templates/partials in your project still work (see `templates/bundles/AdminLTEBundle/`). 
 
 Made public API stricter by adding typehints and adding the final keyword to several classes. 
+
+Inlined some FOSUserBundle translations, to reduce coupling (check your self-registration and password-reset screens).
 
 ## From v2 to v3
 


### PR DESCRIPTION
## Description

As the FOSUserBundle will never be updated, it is time to get rid of the direct coupling.
First step is to move all used translations to this bundle.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [ ] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
