### PR TITLE
fix badges container in menu

### DIFF
--- a/Resources/views/Macros/menu.html.twig
+++ b/Resources/views/Macros/menu.html.twig
@@ -5,7 +5,9 @@
             <a href="{{ item.hasChildren ? '#': '/' in item.route ? item.route : path(item.route|route_alias, item.routeArgs) }}">
                 {% if item.icon %} <i class="{{ item.icon }}"></i> {% endif %}
                 {% if item.badge is not same as(false) %}
+                <span class="pull-right-container">
                     <small class="label pull-right bg-{{ item.badgeColor }}">{{ item.badge }}</small>
+                </span>
                 {% endif %}
                 {% if item.hasChildren %}<i class="fas fa-angle-left pull-right"></i>{% endif %}
                 <span>{{ item.label|trans }}</span>
@@ -38,6 +40,8 @@
     <i class="{{ item.icon|default(defaultIcon) }}"></i>
     <span>{{ item.label|trans }}</span>
     {% if item.badge is not same as(false) %}
+    <span class="pull-right-container">
         <small class="label pull-right bg-{{ item.badgeColor }}">{{ item.badge }}</small>
+    </span>
     {% endif %}
 {% endmacro %}

--- a/Resources/views/Partials/_menu.html.twig
+++ b/Resources/views/Partials/_menu.html.twig
@@ -21,11 +21,15 @@
 {% macro badges(item) %}
     {% import _self as selfMacros %}
     {% if item.getExtra('badge') is not null %}
-        {{ selfMacros.badge(item.getExtra('badge')) }}
+        <span class="pull-right-container">
+            {{ selfMacros.badge(item.getExtra('badge')) }}
+        </span>
     {% elseif item.getExtra('badges') is not null %}
-        {% for badge in item.getExtra('badges') %}
-            {{ selfMacros.badge(badge) }}
-        {% endfor %}
+        <span class="pull-right-container">
+            {% for badge in item.getExtra('badges') %}
+                {{ selfMacros.badge(badge) }}
+            {% endfor %}
+        </span>
     {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
## Description
Add `<span class="pull-right-container"></span>` to contain the badges in the menu like in the original AdminLTE template.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
