### PR TITLE
Allow infobox widget to render without a progress description block

### DIFF
--- a/Resources/views/Widgets/infobox-widget.html.twig
+++ b/Resources/views/Widgets/infobox-widget.html.twig
@@ -16,7 +16,7 @@
             <div class="progress-bar" style="width: {{ progress }}%"></div>
         </div>
         {% endif %}
-        {% if block('progress_description') is defined and progress|default(block('progress_description'))|length > 0 %}
+        {% if block('progress_description') is defined %}
     <span class="progress-description">
       {{ block('progress_description') }}
     </span>

--- a/Resources/views/Widgets/infobox-widget.html.twig
+++ b/Resources/views/Widgets/infobox-widget.html.twig
@@ -16,7 +16,7 @@
             <div class="progress-bar" style="width: {{ progress }}%"></div>
         </div>
         {% endif %}
-        {% if progress|default(block('progress_description'))|length > 0 %}
+        {% if block('progress_description') is defined and progress|default(block('progress_description'))|length > 0 %}
     <span class="progress-description">
       {{ block('progress_description') }}
     </span>


### PR DESCRIPTION
## Description
Info blocks do need some progress description block always. If you don't want one, you have to define it anyways (empty) in order to not let that widget crash while rendering.
This fix changes the progress_description block to optional.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
