### PR TITLE
Change name of CSS file from adminlte 3

### DIFF
--- a/Resources/assets/admin-lte.js
+++ b/Resources/assets/admin-lte.js
@@ -14,7 +14,7 @@ require('daterangepicker');
 
 // ------ AdminLTE framework ------
 require('./admin-lte.scss');
-require('admin-lte/dist/css/AdminLTE.min.css');
+require('admin-lte/dist/css/adminlte.min.css');
 require('./admin-lte-extensions.scss');
 
 global.$.AdminLTE = {};


### PR DESCRIPTION

## Description

According to the repo, 
the file CSS is no longer with uppercases: https://github.com/ColorlibHQ/AdminLTE/tree/v3/dist/css

FIX error from webpack:
```bash
$ encore dev
Running webpack ...

 ERROR  Failed to compile with 1 errors                                                                                                                                                                                                                       

This dependency was not found:

* admin-lte/dist/css/AdminLTE.min.css in ./vendor/kevinpapst/adminlte-bundle/Resources/assets/admin-lte.js
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
