### PR TITLE
Fix the KnpMenu template

### DIFF
--- a/Resources/docs/knp_menu.md
+++ b/Resources/docs/knp_menu.md
@@ -63,38 +63,60 @@ class KnpMenuBuilderSubscriber implements EventSubscriberInterface
     {
         $menu = $event->getMenu();
 
-        $menu->addChild('MainNavigationMenuItem', [
-       	    'label' => 'MAIN NAVIGATION',
-            'childOptions' => $event->getChildOptions()
-        ])->setAttribute('class', 'header');
-        
-        $menu->addChild('blogId', [
-            'route' => 'item_symfony_route',
-            'label' => 'Blog',
-            'childOptions' => $event->getChildOptions(),
+        $menu->addChild('MainHeader', [
+            'label' => 'MAIN MENU',
             'extras' => [
                 'badge' => [
-                    'color' => 'yellow',
+                    'color' => 'warning',
                     'value' => 4,
                 ],
             ],
-        ])->setLabelAttribute('icon', 'fas fa-tachometer-alt');
-        
-        $menu->getChild('blogId')->addChild('ChildOneItemId', [
-            'route' => 'child_1_route',
-            'label' => 'ChildOneDisplayName',
+        ])->setAttribute('class', 'nav-header');
+
+        $level1 = $menu->addChild('level_1', [
+            'label' => 'Level 1',
+            'childOptions' => $event->getChildOptions(),
+            'extras' => [
+                'badge' => [
+                    'color' => 'warning',
+                    'value' => 2,
+                ],
+            ],
+        ])->setLabelAttribute('icon', 'fas fa-circle');
+
+        $level1->addChild('level_1-1', [
+            'route' => 'home',
+            'label' => 'Level 1.1',
             'extras' => [
                 'badges' => [
-                    [ 'value' => 6, 'color' => 'blue' ],
-                    [ 'value' => 5, ],
+                    [ 'value' => 1 ],
+                    [ 'value' => 1, 'color' => 'primary' ],
                 ],
             ],
             'childOptions' => $event->getChildOptions()
-        ])->setLabelAttribute('icon', 'fas fa-rss-square');
-        
-        $menu->getChild('blogId')->addChild('ChildTwoItemId', [
-            'route' => 'child_2_route',
-            'label' => 'ChildTwoDisplayName',
+        ])->setLabelAttribute('icon', 'far fa-circle');
+
+        $level1->addChild('level_1-2', [
+            'route' => 'home',
+            'label' => 'level 1.2',
+            'extras' => [
+                'badges' => [
+                    [ 'value' => 2 ],
+                    [ 'value' => 1, 'color' => 'primary' ],
+                ],
+            ],
+            'childOptions' => $event->getChildOptions()
+        ])->setLabelAttribute('icon', 'far fa-circle');
+
+        $menu->addChild('level_2', [
+            'route' => 'home',
+            'label' => 'Level 2',
+            'childOptions' => $event->getChildOptions()
+        ])->setLabelAttribute('icon', 'fas fa-circle');
+
+        $menu->addChild('level_3', [
+            'route' => 'home',
+            'label' => 'Level 3',
             'childOptions' => $event->getChildOptions()
         ]);
     }
@@ -121,26 +143,60 @@ class KnpMenuBuilderListener
     {
         $menu = $event->getMenu();
 
-        $menu->addChild('MainNavigationMenuItem', [
-       	    'label' => 'MAIN NAVIGATION',
+        $menu->addChild('MainHeader', [
+            'label' => 'MAIN MENU',
+            'extras' => [
+                'badge' => [
+                    'color' => 'warning',
+                    'value' => 4,
+                ],
+            ],
+        ])->setAttribute('class', 'nav-header');
+
+        $level1 = $menu->addChild('level_1', [
+            'label' => 'Level 1',
+            'childOptions' => $event->getChildOptions(),
+            'extras' => [
+                'badge' => [
+                    'color' => 'warning',
+                    'value' => 2,
+                ],
+            ],
+        ])->setLabelAttribute('icon', 'fas fa-circle');
+
+        $level1->addChild('level_1-1', [
+            'route' => 'home',
+            'label' => 'Level 1.1',
+            'extras' => [
+                'badges' => [
+                    [ 'value' => 1 ],
+                    [ 'value' => 1, 'color' => 'primary' ],
+                ],
+            ],
             'childOptions' => $event->getChildOptions()
-        ])->setAttribute('class', 'header');
-        
-        $menu->addChild('blogId', [
-            'route' => 'item_symfony_route',
-            'label' => 'Blog',
+        ])->setLabelAttribute('icon', 'far fa-circle');
+
+        $level1->addChild('level_1-2', [
+            'route' => 'home',
+            'label' => 'level 1.2',
+            'extras' => [
+                'badges' => [
+                    [ 'value' => 2 ],
+                    [ 'value' => 1, 'color' => 'primary' ],
+                ],
+            ],
             'childOptions' => $event->getChildOptions()
-        ])->setLabelAttribute('icon', 'fas fa-tachometer-alt');
-        
-        $menu->getChild('blogId')->addChild('ChildOneItemId', [
-            'route' => 'child_1_route',
-            'label' => 'ChildOneDisplayName',
+        ])->setLabelAttribute('icon', 'far fa-circle');
+
+        $menu->addChild('level_2', [
+            'route' => 'home',
+            'label' => 'Level 2',
             'childOptions' => $event->getChildOptions()
-        ])->setLabelAttribute('icon', 'fas fa-rss-square');
-        
-        $menu->getChild('blogId')->addChild('ChildTwoItemId', [
-            'route' => 'child_2_route',
-            'label' => 'ChildTwoDisplayName',
+        ])->setLabelAttribute('icon', 'fas fa-circle');
+
+        $menu->addChild('level_3', [
+            'route' => 'home',
+            'label' => 'Level 3',
             'childOptions' => $event->getChildOptions()
         ]);
     }

--- a/Resources/docs/knp_menu.md
+++ b/Resources/docs/knp_menu.md
@@ -98,7 +98,7 @@ class KnpMenuBuilderSubscriber implements EventSubscriberInterface
 
         $level1->addChild('level_1-2', [
             'route' => 'home',
-            'label' => 'level 1.2',
+            'label' => 'Level 1.2',
             'extras' => [
                 'badges' => [
                     [ 'value' => 2 ],
@@ -178,7 +178,7 @@ class KnpMenuBuilderListener
 
         $level1->addChild('level_1-2', [
             'route' => 'home',
-            'label' => 'level 1.2',
+            'label' => 'Level 1.2',
             'extras' => [
                 'badges' => [
                     [ 'value' => 2 ],

--- a/Resources/views/Partials/_menu.html.twig
+++ b/Resources/views/Partials/_menu.html.twig
@@ -10,9 +10,9 @@
 
         {% import _self as selfMacros %}
         {% if item.hasChildren and options.depth is not same as(0) and item.displayChildren %}
-            <span class="pull-right-container">
+            <span class="right">
             {{ selfMacros.badges(item) }}
-            <i class="fas fa-angle-left pull-right"></i>
+            <i class="fas fa-angle-left right"></i>
         </span>
         {% else %}
             {{ selfMacros.badges(item) }}
@@ -76,11 +76,12 @@
 {% block spanElement %}
     {% import _self as selfMacros %}
     {% import "knp_menu.html.twig" as macros %}
-    {% if item.attribute('class') matches '/(^|\s+)header(\s+|$)/' %}
+    {% if item.attribute('class') matches '/(^|\s+)nav-header(\s+|$)/' %}
+        {{ item.label }}
         {{ selfMacros.badges(item) }}
     {% else %}
-        <a{{ macros.attributes(item.labelAttributes) }}>
-            {{ selfMacros.badges(item) }}
+        <a class="nav-link" href="#">
+            {{ block('label') }}
         </a>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Description

ATM, the KnpMenu doesn't work.
_Note : Knp Breadcrumb neither.._


Result with the `knp_menu.md` example:
- Item `header` doesn't display :x:
- Item `header` have a bad style :x:
- Item parent (with child) have/need link :x:
- Badges and arrow from items are wrongly positioned :x:
- Wrong badge color used :x:
- No animation from the arrow when opening an item :x: 

![KnpMenu](https://user-images.githubusercontent.com/25293190/143414340-b6496f14-299d-48e8-b348-7ebeae05f878.png)

I've updated the template to match the AdminLTE 3 menu.

#### Template update (nothing too fancy): 
- Changed `header item type` class
- Add `item.label` to header item display
- Changed `<a>` for item with child (remove 'route' required param)
- Changed badge item position & arrow item position

⚠️ Need to change your  `KnpMenuBuilderSubscriber.php` for header items type from `header`  to `nav-header` ⚠️ 
`->setAttribute('class', 'header');` ❌ 
`->setAttribute('class', 'nav-header');` ✔️ 

#### DOC update:
- Changed `Header item` class
- Remove `route` param for item with child
- Changed badge color class
- Add more generic examples with 'level' system


Result after FIX:
![KnpMenu_after](https://user-images.githubusercontent.com/25293190/143416005-7f02e9ac-6c9d-4081-af9a-ef6082dab73a.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
